### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/rnbguy/cargo-languagetool/compare/v0.1.0...v0.2.0) - 2024-05-26
+
+### Added
+- *(cli)* show only uncached results by default
+- *(cli)* enable or disable cache
+
+### Other
+- release-plz workflow file
+- release-plz config

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cargo-languagetool"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "annotate-snippets",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-languagetool"
-version     = "0.1.0"
+version     = "0.2.0"
 authors     = [ "Ranadeep Biswas <mail@rnbguy.at>" ]
 readme      = "README.md"
 repository  = "https://github.com/rnbguy/cargo-languagetool"


### PR DESCRIPTION
## 🤖 New release
* `cargo-languagetool`: 0.1.0 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/rnbguy/cargo-languagetool/compare/v0.1.0...v0.2.0) - 2024-05-26

### Added
- *(cli)* show only uncached results by default
- *(cli)* enable or disable cache

### Other
- release-plz workflow file
- release-plz config
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).