### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/rnbguy/cargo-languagetool/compare/v0.3.1...v0.3.2) - 2024-05-26
+
+### Other
+- github PAT for release trigger
+- update workflow files
+
 ## [0.3.1](https://github.com/rnbguy/cargo-languagetool/compare/v0.3.0...v0.3.1) - 2024-05-26
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cargo-languagetool"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "annotate-snippets",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-languagetool"
-version     = "0.3.1"
+version     = "0.3.2"
 authors     = [ "Ranadeep Biswas <mail@rnbguy.at>" ]
 readme      = "README.md"
 repository  = "https://github.com/rnbguy/cargo-languagetool"


### PR DESCRIPTION
## 🤖 New release
* `cargo-languagetool`: 0.3.1 -> 0.3.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/rnbguy/cargo-languagetool/compare/v0.3.1...v0.3.2) - 2024-05-26

### Other
- github PAT for release trigger
- update workflow files
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).