### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/rnbguy/cargo-languagetool/compare/v0.3.3...v0.4.0) - 2024-05-27
+
+### Other
+- rm Docs methods and call Doc methods directly
+- mv commented fn
+- mv transform_matches logic under Doc
+- import location
+- change method and function names
+- restructure source code
+- nit on names
+
 ## [0.3.3](https://github.com/rnbguy/cargo-languagetool/compare/v0.3.2...v0.3.3) - 2024-05-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cargo-languagetool"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "annotate-snippets",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-languagetool"
-version     = "0.3.3"
+version     = "0.4.0"
 authors     = [ "Ranadeep Biswas <mail@rnbguy.at>" ]
 readme      = "README.md"
 repository  = "https://github.com/rnbguy/cargo-languagetool"


### PR DESCRIPTION
## 🤖 New release
* `cargo-languagetool`: 0.3.3 -> 0.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/rnbguy/cargo-languagetool/compare/v0.3.3...v0.4.0) - 2024-05-27

### Other
- rm Docs methods and call Doc methods directly
- mv commented fn
- mv transform_matches logic under Doc
- import location
- change method and function names
- restructure source code
- nit on names
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).