### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/rnbguy/cargo-languagetool/compare/v0.4.0...v0.4.1) - 2024-06-15
+
+### Fixed
+- filter logic during doc collection
+
+### Other
+- *(deps)* update lockfile
+- cargo format
+
 ## [0.4.0](https://github.com/rnbguy/cargo-languagetool/compare/v0.3.3...v0.4.0) - 2024-05-27
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cargo-languagetool"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "annotate-snippets",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-languagetool"
-version     = "0.4.0"
+version     = "0.4.1"
 authors     = [ "Ranadeep Biswas <mail@rnbguy.at>" ]
 readme      = "README.md"
 repository  = "https://github.com/rnbguy/cargo-languagetool"


### PR DESCRIPTION
## 🤖 New release
* `cargo-languagetool`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/rnbguy/cargo-languagetool/compare/v0.4.0...v0.4.1) - 2024-06-15

### Fixed
- filter logic during doc collection

### Other
- *(deps)* update lockfile
- cargo format
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).