### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/rnbguy/cargo-languagetool/compare/v0.4.1...v0.4.2) - 2024-09-06
+
+### Fixed
+- *(lint)* add reason for allow attribute
+
+### Other
+- update lockfile
+- latest rust release
+
 ## [0.4.1](https://github.com/rnbguy/cargo-languagetool/compare/v0.4.0...v0.4.1) - 2024-06-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cargo-languagetool"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "annotate-snippets",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cargo-languagetool"
-version      = "0.4.1"
+version      = "0.4.2"
 authors      = [ "Ranadeep Biswas <mail@rnbguy.at>" ]
 readme       = "README.md"
 repository   = "https://github.com/rnbguy/cargo-languagetool"


### PR DESCRIPTION
## 🤖 New release
* `cargo-languagetool`: 0.4.1 -> 0.4.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.2](https://github.com/rnbguy/cargo-languagetool/compare/v0.4.1...v0.4.2) - 2024-09-06

### Fixed
- *(lint)* add reason for allow attribute

### Other
- update lockfile
- latest rust release
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).