### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/rnbguy/cargo-languagetool/compare/v0.4.2...v0.4.3) - 2024-10-31
+
+### Other
+
+- apply zizmor suggestions
+
 ## [0.4.2](https://github.com/rnbguy/cargo-languagetool/compare/v0.4.1...v0.4.2) - 2024-09-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cargo-languagetool"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "annotate-snippets",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cargo-languagetool"
-version      = "0.4.2"
+version      = "0.4.3"
 authors      = [ "Ranadeep Biswas <mail@rnbguy.at>" ]
 readme       = "README.md"
 repository   = "https://github.com/rnbguy/cargo-languagetool"


### PR DESCRIPTION
## 🤖 New release
* `cargo-languagetool`: 0.4.2 -> 0.4.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.3](https://github.com/rnbguy/cargo-languagetool/compare/v0.4.2...v0.4.3) - 2024-10-31

### Other

- apply zizmor suggestions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).